### PR TITLE
[개발][자바] java 지원범위 20으로 수정

### DIFF
--- a/java/install-agent-with-buildpack.mdx
+++ b/java/install-agent-with-buildpack.mdx
@@ -39,7 +39,7 @@ tasks.named("bootBuildImage") {
 
 * `BPE_APPEND_JAVA_TOOL_OPTIONS`
 
-  Java 17 버전을 사용하는 경우 필수로 jvm 옵션을 추가하세요.
+  Java 17 버전 이상을 사용하는 경우 필수로 jvm 옵션을 추가하세요.
 
   ```java
   environment["BPE_DELIM_JAVA_TOOL_OPTIONS"] = " "

--- a/java/supported-spec.mdx
+++ b/java/supported-spec.mdx
@@ -18,7 +18,7 @@ Web Application Server (WAS) 뿐 아니라 데몬 및 배치 애플리케이션 
 
   | 지원범위        | 환경 | OS                       | JVM 버전                  |
   | --------------- | ---- | ------------------------ | ------------------------- |
-  | Fully support   | Java | JVM으로 구동하는 모든 OS | Java 6 이상, Java 17 이하 |
+  | Fully support   | Java | JVM으로 구동하는 모든 OS | Java 6 이상, Java 20 이하 |
   | Limited support | Java | JVM으로 구동하는 모든 OS | Java 1.5 이하             |
 
 

--- a/support-env.mdx
+++ b/support-env.mdx
@@ -17,7 +17,7 @@ import TabItem from '@theme/TabItem';
 
 |환경|지원 환경|
 |----|----|
-|Java|Java 6 이상~Java 17 이하|
+|Java|Java 6 이상~Java 20 이하|
 |Node.js|Node.js 7.10.0 이상|
 |PHP|PHP 5.2 이상, 7.0 이상, 8.0 ~ 8.2|
 |Python|Python 2.7, 3.3 이상|


### PR DESCRIPTION
Java Agent 2.2.16 20230908 기준으로 자바에이전트의 지원범위를 java 20으로 수정하였습니다.

[자바에이전트 릴리스노트 2.2.16](https://docs.whatap.io/release-notes/java/java-2_2_16)