### PR TITLE
Java Agent/Update Support Spec

### DIFF
--- a/java/supported-spec.mdx
+++ b/java/supported-spec.mdx
@@ -74,6 +74,8 @@ Web Application Server (WAS) 뿐 아니라 데몬 및 배치 애플리케이션 
 
   * Netty, Akka HTTP 및 Play Framework 등 비동기 Framework
 
+  * Quarkus, Quarkus-reactive
+
   :::note
 
   이외 Java EE Spec을 준수하는 Application Server에서 동작하는 모든 라이브러리를 지원합니다.

--- a/java/supported-spec.mdx
+++ b/java/supported-spec.mdx
@@ -100,7 +100,7 @@ Web Application Server (WAS) 뿐 아니라 데몬 및 배치 애플리케이션 
 
   * MySQL mysql-connector-java
   
-  * Oracle ojdbc14, ojdbc5, ojdbc6, ojdbc7, ojdbc8
+  * Oracle ojdbc5, ojdbc6, ojdbc7, ojdbc8, ojdbc14
   
   * Postgres JDBC
   

--- a/java/supported-spec.mdx
+++ b/java/supported-spec.mdx
@@ -54,7 +54,7 @@ Web Application Server (WAS) 뿐 아니라 데몬 및 배치 애플리케이션 
 
   * Hitachi Cosminexus 7.x, 8.x, 9.x
 
-  * Apache Jakarta Tomcat 6.x, 7.x, 8.x
+  * Apache Jakarta Tomcat 6.x, 7.x, 8.x, 9.x, 10.x
 
   * Caucho Technology Resin 3.x, 4.x
 

--- a/release-notes/java/java-2.2.19.mdx
+++ b/release-notes/java/java-2.2.19.mdx
@@ -25,17 +25,6 @@ pagination_next: release-notes/java/java-2_2_18
 
 - <Status>Feature</Status> Spring Boot 2.5 이상의 Webflux 서비스에서 엑티브 스택 추적
 
-  ```ini title='whatap.conf'
-  # spring-boot-2.5.0 or later
-  weaving=spring-boot-2.5
-
-  # spring-boot-2.7.0 or later
-  weaving=spring-boot-2.7
-
-  # spring-boot-3.0.0 or later
-  weaving=spring-boot-3.0
-  ```
-
 - <Status>Feature</Status> 트랜잭션의 thread id 추적
 
   ```ini title='whatap.conf'


### PR DESCRIPTION
지원 범위
- Quarkus, Quarkus-Reactive 프레임워크 추가 (Java Agent 2.2.19)
- Tomcat 9, Tomcat 10 지원 추가 

릴리스 노트 (Java Agent 2.2.19)
- 불필요한 가이드 제거

기타
- ojdbc 드라이버 순서 변경