### PR TITLE
[개발] Java Agent 2.2.21 릴리스 노트 수정

### DIFF
--- a/release-notes/java/java-2.2.21.mdx
+++ b/release-notes/java/java-2.2.21.mdx
@@ -7,7 +7,7 @@ pagination_next: release-notes/java/java-2_2_20
 
 2023년 11월 02일
 
-- <Status>Changed</Status> <code>trace_redis_param_enabled</code> 추가
+- <Status>Changed</Status> spring-boot에서 kafka 추적시 트랜잭션 표시를 “kafka:”에서 “[kafka]”로 수정
 
 - <Status>Fixed</Status> spring-boot-2.5에서 reactor 사용 시 <code>Mono.just().block()</code>을 사용하는 경우 추적코드로 인해서 <code>block()</code> 에러가 발생하는 현상 방지
 


### PR DESCRIPTION
Java Agent 2.2.21 릴리스 노트 수정
- 사전 작성한 릴리스 노트에 잘못된 정보 제공하여 수정 요청드립니다.