### PR TITLE
[개발][java] 프레임워크 지원 추가: mule-3.9.5, mule-4.5, spring-boot-2.1.x

### DIFF
--- a/java/agent-weaving.mdx
+++ b/java/agent-weaving.mdx
@@ -32,6 +32,8 @@ Java 에이전트를 통해 추적하고 있는 프레임워크 또는 오픈소
 | ^ | mongodb-4.0.3 이상 | `weaving=mongodb-4.0.3` | <Link to="../release-notes/java/java-2_2_11" target="_blank">v2.2.11</Link> | - |
 | ^ | mongodb-4.4 이상 | `weaving=mongodb-4.4` | <Link to="../release-notes/java/java-2_2_11" target="_blank">v2.2.11</Link> | - |
 | ^ | mongodb-4.8 이상 | `weaving=mongodb-4.8` | <Link to="../release-notes/java/java-2_2_11" target="_blank">v2.2.11</Link> | - |
+| mule framework | mule-3.9.5 이상 | `weaving=mule-4.9.5` | <Link to="../release-notes/java/java-2_2_23" target="_blank">v2.2.23</Link> | - |
+| ^ | mule-4.5 이상 | `weaving=mongodb-4.5` | <Link to="../release-notes/java/java-2_2_23" target="_blank">v2.2.23</Link> | - |
 | okhttp | okhttp-2.7 이상 | `weaving=okhttp-2.7` | <Link to="../release-notes/java/java-2_0#v20_15" target="_blank">v2.0_15</Link> | - |
 | ^ | okhttp3 이상 | `weaving=okhttp3` | <Link to="../release-notes/java/java-2_0#v20_15" target="_blank">v2.0_15</Link> | - |
 | ^ | okhttp3-4.4 | `weaving=okhttp3-4.4` | <Link to="../release-notes/java/java-2_2_9" target="_blank">v2.2.9</Link> | - |
@@ -40,7 +42,8 @@ Java 에이전트를 통해 추적하고 있는 프레임워크 또는 오픈소
 | rabbitmq | reactor-rabbitmq-1.2 이상 | `weaving=reactor-rabbitmq-1.2` | <Link to="../release-notes/java/java-2_0#v20_06" target="_blank">v2.0_06</Link> | - |
 | retrofit | retrofit2-2.5 이상 | `weaving=retrofit-2.5` | - | (배포 예정) |
 | ribbon | ribbon | `weaving=ribbon` | <Link to="../release-notes/java/java-2_2_10" target="_blank">v2.2.10</Link> | - |
-| spring-boot | spring-boot-2.5 이상 | `weaving=spring-boot-2.5` | <Link to="../release-notes/java/java-2_2_9" target="_blank">v2.2.9</Link> | kafka-clients, r2dbc-mysql, redis(lettuce), spring-cloud-gateway, spring-webflux, tomcat9, undertow 포함 |
+| spring-boot | spring-boot-2.1 이상 | `weaving=spring-boot-2.1` | <Link to="../release-notes/java/java-2_2_23" target="_blank">v2.2.23</Link> | kafka-clients, r2dbc-mysql, spring-cloud-gateway, spring-webflux, tomcat9, undertow 포함 |
+| ^ | spring-boot-2.5 이상 | `weaving=spring-boot-2.5` | <Link to="../release-notes/java/java-2_2_9" target="_blank">v2.2.9</Link> | kafka-clients, r2dbc-mysql, redis(lettuce), spring-cloud-gateway, spring-webflux, tomcat9, undertow 포함 |
 | ^ | spring-boot-2.7 이상 | `weaving=spring-boot-2.7` | <Link to="../release-notes/java/java-2_2_9" target="_blank">v2.2.9</Link> | jasync-r2dbc-mysql, kafka-clients, r2dbc-mysql, redis(lettuce), spring-cloud-gateway, spring-webflux, tomcat9, undertow 포함 |
 | ^ | spring-boot-3.0 이상 | `weaving=spring-boot-3.0` | <Link to="../release-notes/java/java-2_2_9" target="_blank">v2.2.9</Link> | jasync-r2dbc-mysql, kafka-clients, r2dbc-mysql, redis(lettuce), spring-cloud-gateway,spring-webflux, tomcat10, undertow 포함 |
 | tomcat | tomcat9 | `weaving=tomcat9` | <Link to="../release-notes/java/java-2_2_5" target="_blank">v2.2.5</Link> | - |


### PR DESCRIPTION
비동기/오픈소스 라이브러리 추적 추가
- 프레임워크 지원 추가: mule-3.9.5, mule-4.5, spring-boot-2.1.x 추적
- 라이브러리 지원 추가: spring-boot-2.1.x(kafka-clients-2.0,spring-webflux-5.1.2.RELEASE,spring-cloud-gateway-2.1.0.RELEASE,r2dbc-mysql-0.8.2)

자바에이전트 2.2.23 20231122 버전 추가로 프레임워크 및 비동기 라이브러리 추적 추가 요청드립니다.